### PR TITLE
Rework how the operator bundle is built

### DIFF
--- a/.tekton/gatekeeper-operator-bundle-pull-request.yaml
+++ b/.tekton/gatekeeper-operator-bundle-pull-request.yaml
@@ -12,7 +12,8 @@ metadata:
       ".tekton/gatekeeper-operator-bundle-pull-request.yaml".pathChanged() || 
       ".tekton/gatekeeper-operator-bundle-push.yaml".pathChanged() || 
       "Containerfile.gatekeeper-operator-bundle".pathChanged() ||
-      "gatekeeper-operator".pathChanged())
+      "gatekeeper-operator".pathChanged() ||
+      "bundle-hack/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: olm-operator
@@ -33,7 +34,7 @@ spec:
   - name: dockerfile
     value: Containerfile.gatekeeper-operator-bundle
   - name: hermetic
-    value: "true"
+    value: "false"
   pipelineRef:
     name: single-arch-build-pipeline
   workspaces:

--- a/.tekton/gatekeeper-operator-bundle-push.yaml
+++ b/.tekton/gatekeeper-operator-bundle-push.yaml
@@ -11,7 +11,8 @@ metadata:
       ".tekton/gatekeeper-operator-bundle-pull-request.yaml".pathChanged() || 
       ".tekton/gatekeeper-operator-bundle-push.yaml".pathChanged() || 
       "Containerfile.gatekeeper-operator-bundle".pathChanged() ||
-      "gatekeeper-operator".pathChanged())
+      "gatekeeper-operator".pathChanged() ||
+      "bundle-hack/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: olm-operator
@@ -29,8 +30,9 @@ spec:
     value: quay.io/redhat-user-workloads/konflux-samples-tenant/olm-operator/gatekeeper-operator-bundle:{{revision}}
   - name: dockerfile
     value: Containerfile.gatekeeper-operator-bundle
+  # Do not use hermetic for now as we are going to generate our manifest at build time. We need to pull in content.
   - name: hermetic
-    value: "true"
+    value: "false"
   pipelineRef:
     name: single-arch-build-pipeline
   workspaces:

--- a/Containerfile.gatekeeper-operator-bundle
+++ b/Containerfile.gatekeeper-operator-bundle
@@ -1,4 +1,17 @@
 # Based on ./gatekeeper-operator/bundle.Dockerfile
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder-runner
+RUN microdnf install -y skopeo jq python3 python3-pip
+RUN pip3 install --upgrade pip && pip3 install ruamel.yaml==0.17.9
+
+# Use a new stage to enable caching of the package installations for local development
+FROM builder-runner as builder
+
+COPY bundle-hack .
+COPY gatekeeper-operator/bundle/manifests /manifests/
+COPY gatekeeper-operator/bundle/metadata /metadata/
+
+RUN ./update_bundle.sh 
+
 FROM scratch
 
 # Core bundle labels.
@@ -17,6 +30,6 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
-COPY gatekeeper-operator/bundle/manifests /manifests/
-COPY gatekeeper-operator/bundle/metadata /metadata/
+COPY --from=builder /manifests /manifests/
+COPY --from=builder /metadata /metadata/
 COPY gatekeeper-operator/bundle/tests/scorecard /tests/scorecard/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After merging the initial Tekton PipelineRuns to the repository, the structure o
 
 More information on the specifics for these customizations can be found [below](#functionality-demonstrated-in-this-repository).
 
-This [overhaul PR](https://github.com/konflux-ci/olm-operator-konflux-sample/pull/4) was also merged before 
+NOTE: The multi-arch builds were not properly building the index image until [all architectures](https://github.com/konflux-ci/olm-operator-konflux-sample/pull/15) were enabled.
 
 ### Add more Components as necessary
 

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+export GATEKEEPER_GATEKEEPER_IMAGE_PULLSPEC="quay.io/redhat-user-workloads/konflux-samples-tenant/olm-operator/gatekeeper@sha256:230ac0a06e8d6c298c522d745bd1f8ebcf47e1210c90157ddb033731fad2524c"
+export GATEKEEPER_OPERATOR_IMAGE_PULLSPEC="quay.io/redhat-user-workloads/konflux-samples-tenant/olm-operator/gatekeeper-operator@sha256:7e0e1c2e5f651c497f6e7c361611a0211590ce04509022ff93fa68f52e7e212c"
+
+export CSV_FILE=/manifests/gatekeeper-operator.clusterserviceversion.yaml
+
+sed -i -e "s|quay.io/gatekeeper/gatekeeper:v.*|\"${GATEKEEPER_GATEKEEPER_IMAGE_PULLSPEC}\"|g" \
+	-e "s|quay.io/gatekeeper/gatekeeper-operator:v.*|\"${GATEKEEPER_OPERATOR_IMAGE_PULLSPEC}\"|g" \
+	"${CSV_FILE}"
+
+export AMD64_BUILT=$(skopeo inspect --raw docker://${GATEKEEPER_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="amd64")')
+export ARM64_BUILT=$(skopeo inspect --raw docker://${GATEKEEPER_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="arm64")')
+export PPC64LE_BUILT=$(skopeo inspect --raw docker://${GATEKEEPER_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="ppc64le")')
+export S390X_BUILT=$(skopeo inspect --raw docker://${GATEKEEPER_OPERATOR_IMAGE_PULLSPEC} | jq -e '.manifests[] | select(.platform.architecture=="s390x")')
+
+export EPOC_TIMESTAMP=$(date +%s)
+# time for some direct modifications to the csv
+python3 - << CSV_UPDATE
+import os
+from collections import OrderedDict
+from sys import exit as sys_exit
+from datetime import datetime
+from ruamel.yaml import YAML
+yaml = YAML()
+def load_manifest(pathn):
+   if not pathn.endswith(".yaml"):
+      return None
+   try:
+      with open(pathn, "r") as f:
+         return yaml.load(f)
+   except FileNotFoundError:
+      print("File can not found")
+      exit(2)
+
+def dump_manifest(pathn, manifest):
+   with open(pathn, "w") as f:
+      yaml.dump(manifest, f)
+   return
+timestamp = int(os.getenv('EPOC_TIMESTAMP'))
+datetime_time = datetime.fromtimestamp(timestamp)
+gatekeeper_csv = load_manifest(os.getenv('CSV_FILE'))
+# Add arch support labels
+gatekeeper_csv['metadata']['labels'] = gatekeeper_csv['metadata'].get('labels', {})
+if os.getenv('AMD64_BUILT'):
+	gatekeeper_csv['metadata']['labels']['operatorframework.io/arch.amd64'] = 'supported'
+if os.getenv('ARM64_BUILT'):
+	gatekeeper_csv['metadata']['labels']['operatorframework.io/arch.arm64'] = 'supported'
+if os.getenv('PPC64LE_BUILT'):
+	gatekeeper_csv['metadata']['labels']['operatorframework.io/arch.ppc64le'] = 'supported'
+if os.getenv('S390X_BUILT'):
+	gatekeeper_csv['metadata']['labels']['operatorframework.io/arch.s390x'] = 'supported'
+gatekeeper_csv['metadata']['labels']['operatorframework.io/os.linux'] = 'supported'
+gatekeeper_csv['metadata']['annotations']['createdAt'] = datetime_time.strftime('%d %b %Y, %H:%M')
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/disconnected'] = 'true'
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/fips-compliant'] = 'true'
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/proxy-aware'] = 'false'
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/tls-profiles'] = 'false'
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/token-auth-aws'] = 'false'
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/token-auth-azure'] = 'false'
+gatekeeper_csv['metadata']['annotations']['features.operators.openshift.io/token-auth-gcp'] = 'false'
+gatekeeper_csv['metadata']['annotations']['repository'] = 'https://github.com/stolostron/gatekeeper-operator'
+gatekeeper_csv['metadata']['annotations']['containerImage'] = os.getenv('GATEKEEPER_OPERATOR_IMAGE_PULLSPEC', '')
+
+dump_manifest(os.getenv('CSV_FILE'), gatekeeper_csv)
+CSV_UPDATE
+
+cat $CSV_FILE


### PR DESCRIPTION
This adds net-new steps required to modify a bundle image for Konflux. This type of flow can be added into any existing processing/tooling for bundle generation.

The source CSV already contains the relatedImages section so this tooling does not need to take that into account. If needed, a tool like https://github.com/containerbuildsystem/operator-manifest can be used to generate the relatedImage specification.

By including the pullspecs of all images that will be referenced in the CSV in a single file, it will enable these to be easily nudged in the future after new builds have completed.