### PR TITLE
Pin submodules to a specific branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "gatekeeper-operator"]
 	path = gatekeeper-operator
 	url = https://github.com/stolostron/gatekeeper-operator.git
+	branch = release-3.15
 [submodule "gatekeeper"]
 	path = gatekeeper
 	url = https://github.com/stolostron/gatekeeper.git
+	branch = release-3.15


### PR DESCRIPTION
PRs like
https://github.com/konflux-ci/olm-operator-konflux-sample/pull/18 should not be opened as that changes branches.