### PR TITLE
Decrease image expiration for gatekeeper PRs

### DIFF
--- a/.tekton/gatekeeper-pull-request.yaml
+++ b/.tekton/gatekeeper-pull-request.yaml
@@ -29,7 +29,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/konflux-samples-tenant/olm-operator/gatekeeper:on-pr-{{revision}}
   - name: image-expires-after
-    value: 5d
+    value: 3d
   - name: dockerfile
     value: Containerfile.gatekeeper
   pipelineRef:


### PR DESCRIPTION
The images were just hanging around for too long!