### PR TITLE
Use matrix

### DIFF
--- a/.tekton/gatekeeper-operator-push.yaml
+++ b/.tekton/gatekeeper-operator-push.yaml
@@ -7,10 +7,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_bundle.sh"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && 
-      (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || 
-      ".tekton/gatekeeper-operator-pull-request.yaml".pathChanged() || 
-      ".tekton/gatekeeper-operator-push.yaml".pathChanged() || 
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/multi-arch-build-pipeline.yaml".pathChanged() ||
+      ".tekton/gatekeeper-operator-pull-request.yaml".pathChanged() ||
+      ".tekton/gatekeeper-operator-push.yaml".pathChanged() ||
       "Containerfile.gatekeeper-operator".pathChanged() ||
       "gatekeeper-operator".pathChanged())
   creationTimestamp: null
@@ -30,6 +30,11 @@ spec:
     value: quay.io/redhat-user-workloads/konflux-samples-tenant/olm-operator/gatekeeper-operator:{{revision}}
   - name: dockerfile
     value: Containerfile.gatekeeper-operator
+  - name: platforms
+    value:
+      - linux/amd64
+      - linux/arm64
+      - linux/s390x
   pipelineRef:
     name: multi-arch-build-pipeline
   workspaces:

--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -78,9 +78,9 @@ spec:
         resolver: bundles
         params:
         - name: name
-          value: buildah-remote-oci-ta
+          value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:eaca875dcde9dd714461613a1c549dd5ad55e16b3aac07ec39f515127cd10044
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:46c6bf4872647a80aa8375fab221ea4483356da8a43b5f5b0cdc6a4f76fbc95e
         - name: kind
           value: task
       runAfter:
@@ -90,13 +90,9 @@ spec:
         operator: in
         values:
         - 'true'
-      - input: "$(params.enable-amd64-build)"
-        operator: in
-        values:
-        - 'true'
       params:
       - name: IMAGE
-        value: "$(params.output-image)-amd64"
+        value: $(params.output-image)-amd64
       - name: DOCKERFILE
         value: "$(params.dockerfile)"
       - name: CONTEXT
@@ -115,9 +111,27 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.amd64-platform)
-    - name: build-container-arm64
+    - name: build-containers-multi-platform
+      matrix:
+        include:
+          - name: arm64
+            params:
+              - name: IMAGE
+                value: $(params.output-image)-arm64
+              - name: PLATFORM
+                value: linux/arm64
+          - name: ppc64le
+            params:
+              - name: IMAGE
+                value: $(params.output-image)-ppc64le
+              - name: PLATFORM
+                value: linux/ppc64le
+          - name: s390x
+            params:
+              - name: IMAGE
+                value: $(params.output-image)-s390x
+              - name: PLATFORM
+                value: linux/s390x
       taskRef:
         resolver: bundles
         params:
@@ -134,13 +148,7 @@ spec:
         operator: in
         values:
         - 'true'
-      - input: "$(params.enable-arm64-build)"
-        operator: in
-        values:
-        - 'true'
       params:
-      - name: IMAGE
-        value: "$(params.output-image)-arm64"
       - name: DOCKERFILE
         value: "$(params.dockerfile)"
       - name: CONTEXT
@@ -159,96 +167,6 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.arm64-platform)
-    - name: build-container-ppc64le
-      taskRef:
-        resolver: bundles
-        params:
-        - name: name
-          value: buildah-remote-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:eaca875dcde9dd714461613a1c549dd5ad55e16b3aac07ec39f515127cd10044
-        - name: kind
-          value: task
-      runAfter:
-        - prefetch-dependencies
-      when:
-      - input: "$(tasks.init.results.build)"
-        operator: in
-        values:
-        - 'true'
-      - input: "$(params.enable-ppc64le-build)"
-        operator: in
-        values:
-        - 'true'
-      params:
-      - name: IMAGE
-        value: "$(params.output-image)-ppc64le"
-      - name: DOCKERFILE
-        value: "$(params.dockerfile)"
-      - name: CONTEXT
-        value: "$(params.path-context)"
-      - name: HERMETIC
-        value: "$(params.hermetic)"
-      - name: PREFETCH_INPUT
-        value: "$(params.prefetch-input)"
-      - name: IMAGE_EXPIRES_AFTER
-        value: "$(params.image-expires-after)"
-      - name: COMMIT_SHA
-        value: "$(tasks.clone-repository.results.commit)"
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.ppc64le-platform)
-    - name: build-container-s390x
-      taskRef:
-        resolver: bundles
-        params:
-        - name: name
-          value: buildah-remote-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:eaca875dcde9dd714461613a1c549dd5ad55e16b3aac07ec39f515127cd10044
-        - name: kind
-          value: task
-      runAfter:
-        - prefetch-dependencies
-      when:
-      - input: "$(tasks.init.results.build)"
-        operator: in
-        values:
-        - 'true'
-      - input: "$(params.enable-s390x-build)"
-        operator: in
-        values:
-        - 'true'
-      params:
-      - name: IMAGE
-        value: "$(params.output-image)-s390x"
-      - name: DOCKERFILE
-        value: "$(params.dockerfile)"
-      - name: CONTEXT
-        value: "$(params.path-context)"
-      - name: HERMETIC
-        value: "$(params.hermetic)"
-      - name: PREFETCH_INPUT
-        value: "$(params.prefetch-input)"
-      - name: IMAGE_EXPIRES_AFTER
-        value: "$(params.image-expires-after)"
-      - name: COMMIT_SHA
-        value: "$(tasks.clone-repository.results.commit)"
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.s390x-platform)
     - name: build-image-index
       params:
         - name: IMAGE
@@ -257,21 +175,16 @@ spec:
           value: $(tasks.clone-repository.results.commit)
         - name: IMAGES
           value:
-            - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
-            - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
-            - $(tasks.build-container-s390x.results.IMAGE_URL)@$(tasks.build-container-s390x.results.IMAGE_DIGEST)
-            - $(tasks.build-container-ppc64le.results.IMAGE_URL)@$(tasks.build-container-ppc64le.results.IMAGE_DIGEST)
+            - $(tasks.build-containers-multi-platform.results.IMAGE_REF[*])
+            - $(tasks.build-container-amd64.results.IMAGE_REF)
       runAfter:
-        - build-container-amd64
-        - build-container-arm64
-        - build-container-s390x
-        - build-container-ppc64le
+        - build-containers-multi-platform
       taskRef:
         params:
           - name: name
             value: build-image-manifest
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest:0.1@sha256:231b521c5443a750cfcb302b74633ebe140b5ab0333688c91d32745417cc23a3
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest@sha256:231b521c5443a750cfcb302b74633ebe140b5ab0333688c91d32745417cc23a3
           - name: kind
             value: task
         resolver: bundles
@@ -511,39 +424,6 @@ spec:
       type: string
       description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
       default: ""
-    # We need matrix builds in order to use these "enable architecture" parameters: https://issues.redhat.com/browse/EC-654
-    - name: enable-amd64-build
-      type: string
-      description: Enable amd64 builds 
-      default: "true"
-    - name: enable-arm64-build
-      type: string
-      description: Enable arm64 builds 
-      default: "true"
-    - name: enable-ppc64le-build
-      type: string
-      description: Enable ppc64le builds 
-      default: "true"
-    - name: enable-s390x-build
-      type: string
-      description: Enable s390x builds 
-      default: "true"
-    - name: amd64-platform
-      type: string
-      description: Enable the amd64 platform to be changed from the PipelineRun file
-      default: linux/amd64
-    - name: arm64-platform
-      type: string
-      description: Enable the arm64 platform to be changed from the PipelineRun file
-      default: linux/arm64
-    - name: ppc64le-platform
-      type: string
-      description: Enable the ppc64le platform to be changed from the PipelineRun file
-      default: linux/ppc64le
-    - name: s390x-platform
-      type: string
-      description: Enable the s390x platform to be changed from the PipelineRun file
-      default: linux/s390x
     workspaces:
     - name: git-auth
       optional: true
@@ -562,7 +442,7 @@ spec:
       value: "$(tasks.clone-repository.results.commit)"
     - name: JAVA_COMMUNITY_DEPENDENCIES
       description: ''
-      value: "$(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)"
+      value: "$(tasks.build-containers-multi-platform.results.JAVA_COMMUNITY_DEPENDENCIES[0])"
     finally:
     - name: show-sbom
       taskRef:

--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -73,65 +73,11 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
-    - name: build-container-amd64
-      taskRef:
-        resolver: bundles
-        params:
-        - name: name
-          value: buildah-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:46c6bf4872647a80aa8375fab221ea4483356da8a43b5f5b0cdc6a4f76fbc95e
-        - name: kind
-          value: task
-      runAfter:
-        - prefetch-dependencies
-      when:
-      - input: "$(tasks.init.results.build)"
-        operator: in
-        values:
-        - 'true'
-      params:
-      - name: IMAGE
-        value: $(params.output-image)-amd64
-      - name: DOCKERFILE
-        value: "$(params.dockerfile)"
-      - name: CONTEXT
-        value: "$(params.path-context)"
-      - name: HERMETIC
-        value: "$(params.hermetic)"
-      - name: PREFETCH_INPUT
-        value: "$(params.prefetch-input)"
-      - name: IMAGE_EXPIRES_AFTER
-        value: "$(params.image-expires-after)"
-      - name: COMMIT_SHA
-        value: "$(tasks.clone-repository.results.commit)"
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-    - name: build-containers-multi-platform
+    - name: build-images
       matrix:
-        include:
-          - name: arm64
-            params:
-              - name: IMAGE
-                value: $(params.output-image)-arm64
-              - name: PLATFORM
-                value: linux/arm64
-          - name: ppc64le
-            params:
-              - name: IMAGE
-                value: $(params.output-image)-ppc64le
-              - name: PLATFORM
-                value: linux/ppc64le
-          - name: s390x
-            params:
-              - name: IMAGE
-                value: $(params.output-image)-s390x
-              - name: PLATFORM
-                value: linux/s390x
+        params:
+          - name: PLATFORM
+            value: ["$(params.platforms)"]
       taskRef:
         resolver: bundles
         params:
@@ -153,6 +99,8 @@ spec:
         value: "$(params.dockerfile)"
       - name: CONTEXT
         value: "$(params.path-context)"
+      - name: IMAGE
+        value: "$(params.output-image)"
       - name: HERMETIC
         value: "$(params.hermetic)"
       - name: PREFETCH_INPUT
@@ -175,10 +123,9 @@ spec:
           value: $(tasks.clone-repository.results.commit)
         - name: IMAGES
           value:
-            - $(tasks.build-containers-multi-platform.results.IMAGE_REF[*])
-            - $(tasks.build-container-amd64.results.IMAGE_REF)
+            - $(tasks.build-images.results.IMAGE_REF[*])
       runAfter:
-        - build-containers-multi-platform
+        - build-images
       taskRef:
         params:
           - name: name
@@ -424,6 +371,11 @@ spec:
       type: string
       description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
       default: ""
+    - name: enabled-platforms
+      type: array
+      description: List of enabled platforms in the form of os/architecture,
+        e.g. linux/amd64, linux/arm64
+      default: ["linux/amd64"]
     workspaces:
     - name: git-auth
       optional: true
@@ -442,7 +394,7 @@ spec:
       value: "$(tasks.clone-repository.results.commit)"
     - name: JAVA_COMMUNITY_DEPENDENCIES
       description: ''
-      value: "$(tasks.build-containers-multi-platform.results.JAVA_COMMUNITY_DEPENDENCIES[0])"
+      value: "$(tasks.build-images.results.JAVA_COMMUNITY_DEPENDENCIES[0])"
     finally:
     - name: show-sbom
       taskRef:


### PR DESCRIPTION
This makes use of the matrix[1] feature of Tekton Piplines to reduce the
duplication of Tasks in the `multi-arch-build-pipeline` Pipeline
definition.

In addition to that the linux/amd64 build is not performed using
`buildah-remote` but using `buildah`.

[1] https://tekton.dev/docs/pipelines/matrix/