### PR TITLE
Change remote builds to use a matrix

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -11,7 +11,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:99c98d3e5195e9920482f2187590d6f9150c4b8a2001b1ce5dcd5077abda9481
         - name: kind
           value: task
       params:
@@ -28,7 +28,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:cb23ff0e47501f7badac0b0ce61ca6ba4a1ada79352835272c440001a2a2c0c1
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:b44ea49656037376056e62cb39d4ed73e5215814556be832f2a425eec31204ab
         - name: kind
           value: task
       when:
@@ -57,7 +57,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:1e4787ce13ca515a70312c27e304ed6a1d3e63840863f4c841f2f1687d7df45f
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:f38728dc492d20582a39b71da4c987ad0ec02f88893e2138c500c8493606c4ac
         - name: kind
           value: task
       params:
@@ -78,9 +78,9 @@ spec:
         resolver: bundles
         params:
         - name: name
-          value: buildah-remote-oci-ta
+          value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:46c6bf4872647a80aa8375fab221ea4483356da8a43b5f5b0cdc6a4f76fbc95e
         - name: kind
           value: task
       runAfter:
@@ -90,13 +90,12 @@ spec:
         operator: in
         values:
         - 'true'
-      - input: "$(params.enable-amd64-build)"
+      - input: "$(params.build-amd-in-cluster)"
         operator: in
-        values:
-        - 'true'
+        values: ['true']
       params:
       - name: IMAGE
-        value: "$(params.output-image)-amd64"
+        value: $(params.output-image)-amd64
       - name: DOCKERFILE
         value: "$(params.dockerfile)"
       - name: CONTEXT
@@ -115,9 +114,36 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.amd64-platform)
-    - name: build-container-arm64
+    - name: build-containers-multi-platform
+      matrix:
+        include:
+          # While this is possible to do, we build amd64 in-cluster instead.
+          #  In order to build amd64 remotely, uncomment this and disable
+          #  the in-cluster task by setting params.build-amd-in-cluster to false
+          # - name: amd64
+          #   params:
+          #     - name: IMAGE
+          #       value: $(params.output-image)-amd64
+          #     - name: PLATFORM
+          #       value: $(params.amd64-platform)
+          - name: arm64
+            params:
+              - name: IMAGE
+                value: $(params.output-image)-arm64
+              - name: PLATFORM
+                value: $(params.arm64-platform)
+          - name: ppc64le
+            params:
+              - name: IMAGE
+                value: $(params.output-image)-ppc64le
+              - name: PLATFORM
+                value: $(params.ppc64le-platform)
+          - name: s390x
+            params:
+              - name: IMAGE
+                value: $(params.output-image)-s390x
+              - name: PLATFORM
+                value: $(params.s390x-platform)
       taskRef:
         resolver: bundles
         params:
@@ -134,13 +160,7 @@ spec:
         operator: in
         values:
         - 'true'
-      - input: "$(params.enable-arm64-build)"
-        operator: in
-        values:
-        - 'true'
       params:
-      - name: IMAGE
-        value: "$(params.output-image)-arm64"
       - name: DOCKERFILE
         value: "$(params.dockerfile)"
       - name: CONTEXT
@@ -159,96 +179,6 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.arm64-platform)
-    - name: build-container-ppc64le
-      taskRef:
-        resolver: bundles
-        params:
-        - name: name
-          value: buildah-remote-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
-        - name: kind
-          value: task
-      runAfter:
-        - prefetch-dependencies
-      when:
-      - input: "$(tasks.init.results.build)"
-        operator: in
-        values:
-        - 'true'
-      - input: "$(params.enable-ppc64le-build)"
-        operator: in
-        values:
-        - 'true'
-      params:
-      - name: IMAGE
-        value: "$(params.output-image)-ppc64le"
-      - name: DOCKERFILE
-        value: "$(params.dockerfile)"
-      - name: CONTEXT
-        value: "$(params.path-context)"
-      - name: HERMETIC
-        value: "$(params.hermetic)"
-      - name: PREFETCH_INPUT
-        value: "$(params.prefetch-input)"
-      - name: IMAGE_EXPIRES_AFTER
-        value: "$(params.image-expires-after)"
-      - name: COMMIT_SHA
-        value: "$(tasks.clone-repository.results.commit)"
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.ppc64le-platform)
-    - name: build-container-s390x
-      taskRef:
-        resolver: bundles
-        params:
-        - name: name
-          value: buildah-remote-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:940d9c1b107fa07c1f75062a102319ee9f75bc1c3e70f739827530290e8c3b1b
-        - name: kind
-          value: task
-      runAfter:
-        - prefetch-dependencies
-      when:
-      - input: "$(tasks.init.results.build)"
-        operator: in
-        values:
-        - 'true'
-      - input: "$(params.enable-s390x-build)"
-        operator: in
-        values:
-        - 'true'
-      params:
-      - name: IMAGE
-        value: "$(params.output-image)-s390x"
-      - name: DOCKERFILE
-        value: "$(params.dockerfile)"
-      - name: CONTEXT
-        value: "$(params.path-context)"
-      - name: HERMETIC
-        value: "$(params.hermetic)"
-      - name: PREFETCH_INPUT
-        value: "$(params.prefetch-input)"
-      - name: IMAGE_EXPIRES_AFTER
-        value: "$(params.image-expires-after)"
-      - name: COMMIT_SHA
-        value: "$(tasks.clone-repository.results.commit)"
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: PLATFORM
-        value: $(params.s390x-platform)
     - name: build-image-index
       params:
         - name: IMAGE
@@ -257,15 +187,10 @@ spec:
           value: $(tasks.clone-repository.results.commit)
         - name: IMAGES
           value:
-            - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
-            - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
-            - $(tasks.build-container-s390x.results.IMAGE_URL)@$(tasks.build-container-s390x.results.IMAGE_DIGEST)
-            - $(tasks.build-container-ppc64le.results.IMAGE_URL)@$(tasks.build-container-ppc64le.results.IMAGE_DIGEST)
+            - $(tasks.build-containers-multi-platform.results.IMAGE_REF[*])
+            - $(tasks.build-container-amd64.results.IMAGE_REF)
       runAfter:
-        - build-container-amd64
-        - build-container-arm64
-        - build-container-s390x
-        - build-container-ppc64le
+        - build-containers-multi-platform
       taskRef:
         params:
           - name: name
@@ -287,7 +212,7 @@ spec:
         - name: name
           value: source-build-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:99ee22c5e8e8a66da3d68ec5f3334e7cc59f8b8907e9d2a78f7338aa37d952eb
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:823b0b7aef15d283252dc3b5c684ae0d6adbf213067b72a5dd08a9b8af1244b6
         - name: kind
           value: task
       when:
@@ -359,7 +284,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:f0b2ee5d02fdff0ea32af13e26f481f6b66bddfc1357cf171b8e7525a38f09d4
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
         - name: kind
           value: task
       when:
@@ -379,7 +304,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:d1989870f1078f164eb90848005a2cdcbf0df4dd2d357f7c35ff39cac3ec43e2
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:e531f06bdb9323889417d5649f544d423c1217e72ada0bc3f1b07a29f4a3c1f1
         - name: kind
           value: task
       when:
@@ -451,7 +376,7 @@ spec:
         - name: name
           value: apply-tags
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:516875845f2988848ebde5f3e9c717d6077af7bf9b3cb2b34a3c3f86b2609a14
         - name: kind
           value: task
         resolver: bundles
@@ -511,38 +436,25 @@ spec:
       type: string
       description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
       default: ""
-    # We need matrix builds in order to use these "enable architecture" parameters: https://issues.redhat.com/browse/EC-654
-    - name: enable-amd64-build
+    - name: build-amd-in-cluster
       type: string
-      description: Enable amd64 builds 
-      default: "true"
-    - name: enable-arm64-build
-      type: string
-      description: Enable arm64 builds 
-      default: "true"
-    - name: enable-ppc64le-build
-      type: string
-      description: Enable ppc64le builds 
-      default: "true"
-    - name: enable-s390x-build
-      type: string
-      description: Enable s390x builds 
-      default: "true"
+      description: Whether to build amd64 images in-cluster. Set to false if planning to build amd64 remotely.
+      default: 'true'
     - name: amd64-platform
       type: string
-      description: Enable the amd64 platform to be changed from the PipelineRun file
+      description: Platform to use for amd64 remote builds
       default: linux/amd64
     - name: arm64-platform
       type: string
-      description: Enable the arm64 platform to be changed from the PipelineRun file
+      description: Platform to use for arm64 remote builds
       default: linux/arm64
     - name: ppc64le-platform
       type: string
-      description: Enable the ppc64le platform to be changed from the PipelineRun file
+      description: Platform to use for ppc64le remote builds
       default: linux/ppc64le
     - name: s390x-platform
       type: string
-      description: Enable the s390x platform to be changed from the PipelineRun file
+      description: Platform to use for s390x remote builds
       default: linux/s390x
     workspaces:
     - name: git-auth
@@ -562,7 +474,7 @@ spec:
       value: "$(tasks.clone-repository.results.commit)"
     - name: JAVA_COMMUNITY_DEPENDENCIES
       description: ''
-      value: "$(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)"
+      value: "$(tasks.build-containers-multi-platform.results.JAVA_COMMUNITY_DEPENDENCIES[0])"
     finally:
     - name: show-sbom
       taskRef:


### PR DESCRIPTION
Even if the user interaction isn't simplified (i.e. repo owners still need to touch the pipelineDefinition to change which images are built), this further reduces duplication of task definitions.