### PR TITLE
Add drift protection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = gatekeeper
 	url = https://github.com/stolostron/gatekeeper.git
 	branch = release-3.15
+[submodule "drift-detection"]
+	path = drift-detection
+	url = https://github.com/arewm/drift-detection

--- a/Containerfile.gatekeeper
+++ b/Containerfile.gatekeeper
@@ -1,6 +1,13 @@
 # Based on ./gatekeeper/Dockerfile
 FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-7.1724661022 as builder
 USER 0
+COPY drift-detection/detector.sh /detector.sh
+# Check to see if we need to react to any uptream changes
+COPY drift-cache /drift-cache
+WORKDIR /tmp
+COPY gatekeeper/Dockerfile .
+RUN /detector.sh ./Dockerfile /drift-cache/gatekeeper/Dockerfile
+
 ENV LDFLAGS="-X github.com/open-policy-agent/gatekeeper/v3/pkg/version.Version=v3.15.1" \
     GO111MODULE=on \
     CGO_ENABLED=1

--- a/Containerfile.gatekeeper-operator
+++ b/Containerfile.gatekeeper-operator
@@ -2,6 +2,13 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-7.1724661022 as builder
 USER 0
+COPY drift-detection/detector.sh /detector.sh
+# Check to see if we need to react to any uptream changes
+COPY drift-cache /drift-cache
+WORKDIR /tmp
+COPY gatekeeper-operator/Dockerfile .
+RUN /detector.sh ./Dockerfile /drift-cache/gatekeeper-operator/Dockerfile
+
 ENV LDFLAGS="-X ${VERSION_PKG}.gitVersion=v3.15.1-7 \
              -X ${VERSION_PKG}.gitCommit=59587323ce32580b4dffba0a09b1ca22109925db \
              -X ${VERSION_PKG}.gitTreeState=clean \

--- a/docs/functionality-demonstrated.md
+++ b/docs/functionality-demonstrated.md
@@ -63,3 +63,9 @@ While this results in improved resource utilization (lower cloud spend), it does
 ## Customization of files for component nudging
 
 The gatekeeper and gatekeeper operator's "push" pipelines both specify the file to nudge component references in via the `build.appstudio.openshift.io/build-nudge-files` annotation. Since the location of the component references is atypical (i.e. not a Containerfile or yaml file), we need to configure this annotation. Once this annotation is set, the newly built operand and operator images will trigger a pull request against the `update_bundle.sh` file (i.e. konflux-ci/olm-operator-konflux-sample#21 and konflux-ci/olm-operator-konflux-sample#22).
+
+## Preventing build process drift in submodules
+
+Git submodules are a convenient way to vendor source code, especially if you want to build the repositories without having to manage updating a fork and maintaining your own build-specific configurations during these syncs. One disadvantage to these submodules, however, is that the updates included can easily be opaque which can easily result in drift between your build process and that of the original repository. This becomes harder when you have an external tool like Renovate which automatically suggests updates to the submodules.
+
+This functionality is documented further in konflux-ci/olm-operator-konflux-sample#71 as well as in [konflux-onboarding.md](./konflux-onboarding.md#enable-drift-detection-optional).

--- a/drift-cache/gatekeeper-operator/Dockerfile
+++ b/drift-cache/gatekeeper-operator/Dockerfile
@@ -1,0 +1,32 @@
+# Build the manager binary
+FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux as builder
+
+ARG GOOS
+ARG GOARCH
+ARG LDFLAGS
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=1 GOOS=${GOOS} GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/drift-cache/gatekeeper/Dockerfile
+++ b/drift-cache/gatekeeper/Dockerfile
@@ -1,4 +1,3 @@
-# Adding simulated drift!
 ARG BUILDPLATFORM="linux/amd64"
 ARG BUILDERIMAGE="golang:1.21-bullseye"
 # Use distroless as minimal base image to package the manager binary
@@ -6,6 +5,12 @@ ARG BUILDERIMAGE="golang:1.21-bullseye"
 ARG BASEIMAGE="gcr.io/distroless/cc-debian11:nonroot"
 
 FROM --platform=$BUILDPLATFORM $BUILDERIMAGE as builder
+
+
+
+
+
+
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/drift-cache/gatekeeper/Dockerfile
+++ b/drift-cache/gatekeeper/Dockerfile
@@ -1,0 +1,44 @@
+ARG BUILDPLATFORM="linux/amd64"
+ARG BUILDERIMAGE="golang:1.21-bullseye"
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+ARG BASEIMAGE="gcr.io/distroless/cc-debian11:nonroot"
+
+FROM --platform=$BUILDPLATFORM $BUILDERIMAGE as builder
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
+ARG LDFLAGS
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=1 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT}
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        apt -y update && apt -y install gcc-aarch64-linux-gnu && apt -y clean all; \
+    elif [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then \
+        apt -y update && apt -y install gcc-arm-linux-gnueabihf && apt -y clean all; \
+    fi
+
+WORKDIR /go/src/github.com/open-policy-agent/gatekeeper
+COPY . .
+
+RUN  if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        export CC=aarch64-linux-gnu-gcc; \
+    elif [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then \
+        export CC=arm-linux-gnueabihf-gcc; \
+    fi; \
+    go build -mod vendor -a -ldflags "${LDFLAGS}" -o manager
+   
+
+FROM $BASEIMAGE
+
+WORKDIR /
+COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/manager .
+USER 65532:65532
+ENTRYPOINT ["/manager"]

--- a/drift-cache/gatekeeper/Dockerfile
+++ b/drift-cache/gatekeeper/Dockerfile
@@ -1,3 +1,4 @@
+# Adding simulated drift!
 ARG BUILDPLATFORM="linux/amd64"
 ARG BUILDERIMAGE="golang:1.21-bullseye"
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
When including git submodules, it is possible for build configurations to drift resulting in the artifacts being built improperly. In order to identify these situations, we will fail the builds when drift is detected.