### PR TITLE
Remove bundle labels in the catalog containerfile

### DIFF
--- a/v4.13/Containerfile.catalog
+++ b/v4.13/Containerfile.catalog
@@ -8,14 +8,5 @@ COPY catalog/ /configs
 
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
-# Core bundle labels.
-
-LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=gatekeeper-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.1
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+# Set specific label for the location of the declarative config root directory in the image
 LABEL operators.operatorframework.io.index.configs.v1=/configs


### PR DESCRIPTION
Looking at FBC catalog example in operator-framework repo - https://github.com/operator-framework/cool-catalog/blob/main/catalog.Dockerfile, the only label required on catalog images is 

```
LABEL operators.operatorframework.io.index.configs.v1=/configs
```

Applying bundle labels to the catalog image may disrupt the opm render tooling, as it determines the image type by fingerprinting it using those labels.

For this reason this PR removes all bundle labels of the sample catalog containerfile (except `operators.operatorframework.io.index.configs.v1=/configs`).